### PR TITLE
Fix build under API-23

### DIFF
--- a/Superuser/src/com/koushikdutta/superuser/util/StreamUtility.java
+++ b/Superuser/src/com/koushikdutta/superuser/util/StreamUtility.java
@@ -14,14 +14,6 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import android.net.http.AndroidHttpClient;
-
 public class StreamUtility {
  //private static final String LOGTAG = StreamUtility.class.getSimpleName();
     public static void fastChannelCopy(final ReadableByteChannel src, final WritableByteChannel dest) throws IOException {
@@ -49,31 +41,6 @@ public class StreamUtility {
         final WritableByteChannel outputChannel = Channels.newChannel(output);
         // copy the channels
         fastChannelCopy(inputChannel, outputChannel);
-    }
-
-    public static String downloadUriAsString(String uri) throws IOException {
-        HttpGet get = new HttpGet(uri);
-        return downloadUriAsString(get);
-    }
-
-
-    public static String downloadUriAsString(final HttpUriRequest req) throws IOException {
-        AndroidHttpClient client = AndroidHttpClient.newInstance("Android");
-        try {
-            HttpResponse res = client.execute(req);
-            return readToEnd(res.getEntity().getContent());
-        }
-        finally {
-            client.close();
-        }
-    }
-
-    public static JSONObject downloadUriAsJSONObject(String uri) throws IOException, JSONException {
-        return new JSONObject(downloadUriAsString(uri));
-    }
-
-    public static JSONObject downloadUriAsJSONObject(HttpUriRequest req) throws IOException, JSONException {
-        return new JSONObject(downloadUriAsString(req));
     }
 
     public static byte[] readToEndAsArray(InputStream input) throws IOException


### PR DESCRIPTION
Apache HTTP client is deprecated in Android 6.0. Since the functions it is used in are not actually used in anything, there is no need to update them to HttpURLConnection. Just remove them.

Ref: https://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-apache-http-client