### PR TITLE
Don't set LD_LIBRARY_PATH

### DIFF
--- a/Superuser/jni/su/su.c
+++ b/Superuser/jni/su/su.c
@@ -653,12 +653,6 @@ int su_main_nodaemon(int argc, char **argv) {
         cp++;
     }
 
-    /*
-     * set LD_LIBRARY_PATH if the linker has wiped out it due to we're suid.
-     * This occurs on Android 4.0+
-     */
-    setenv("LD_LIBRARY_PATH", "/vendor/lib64:/system/lib64:/vendor/lib:/system/lib", 0);
-
     LOGD("su invoked.");
 
     struct su_context ctx = {


### PR DESCRIPTION
I was getting this kind of error running a 32 bit binary on a 64 bit Nexus 9:
```
CANNOT LINK EXECUTABLE: "/system/lib64/libstdc++.so" is 64-bit instead of 32-bit
page record for 0xf733503c was not found (block_size=16)
```

Bionic's linker already has the proper paths built in, LD_LIBRARY_PATH should only be used for overriding the default paths, the variable *SHOULD* be unset.