### PR TITLE
Fix Superuser on 64 bits target

### DIFF
--- a/Superuser/jni/su/su.c
+++ b/Superuser/jni/su/su.c
@@ -387,7 +387,7 @@ static int socket_accept(int serv_fd) {
 static int socket_send_request(int fd, const struct su_context *ctx) {
 #define write_data(fd, data, data_len)              \
 do {                                                \
-    size_t __len = htonl(data_len);                 \
+    uint32_t __len = htonl(data_len);               \
     __len = write((fd), &__len, sizeof(__len));     \
     if (__len != sizeof(__len)) {                   \
         PLOGE("write(" #data ")");                  \


### PR DESCRIPTION
 - An export to "/system/lib" is not required and cause problems
   as this is a 32 bits lib dir only
 - When writing to socket, datatype size_t was used, which is
   4 bytes on 32 bits target and 8 bytes on 64 bits.
   Superuser expects it as a 4 bytes length. So, it was
   replaced by "uint32_t" datatype