### PR TITLE
Initial creation of 64-bit builds

### DIFF
--- a/Superuser/assets/update-binary
+++ b/Superuser/assets/update-binary
@@ -45,8 +45,20 @@ cp $PLATFORM/su /system/xbin/su
 chown 0:0 /system/xbin/su
 chmod 0755 /system/xbin/su
 
-cp Superuser.apk /system/app
-chmod 644 /system/app/Superuser.apk
+if test '/system/app/*/*.apk' != /system/app/*/*.apk 2>/dev/null
+then
+  mkdir -m 755 -p /system/app/Superuser
+  cp Superuser.apk /system/app/Superuser
+  chmod 644 /system/app/Superuser/Superuser.apk
+#elif test '/system/app/*.apk' != /system/app/*.apk 2>/dev/null
+#then
+else
+  cp Superuser.apk /system/app
+  chmod 644 /system/app/Superuser.apk
+#else
+#  echo -n -e 'ui_print Install location for Superuser.apk unknown, failed\n' > /proc/self/fd/$2
+#  exit 1
+fi
 
 # if the system is at least 4.3, and there is no su daemon built in,
 # let's try to install it using install-recovery.sh

--- a/Superuser/assets/update-binary
+++ b/Superuser/assets/update-binary
@@ -10,13 +10,17 @@ echo -n -e 'ui_print\n' > /proc/self/fd/$2
 ARCH=$(uname -m)
 
 # x86 needs to match: i486, i686, x86_64, ...
-if echo "$ARCH" | grep -q 86; then
-  PLATFORM=x86
-elif [ "$ARCH" = "mips" -o "$ARCH" = "mips64" ]; then
-  PLATFORM=mips
-else
-  PLATFORM=armeabi
-fi
+case "${ARCH}" in
+  (*86*)
+    PLATFORM=x86
+  ;;
+  (arm|armel|armeabi|aarch64|arm64-v8a)
+    PLATFORM=armeabi
+  ;;
+  (mips|mips64)
+    PLATFORM=mips
+  ;;
+esac
 
 cd /tmp
 mkdir superuser
@@ -87,6 +91,7 @@ for i in etc/install-recovery.sh bin/install-recovery.sh bin/install_recovery.sh
 done
 
 #Rename original app_process32
+#TODO: add support for adding a hook into app_process64
 if [ ! -f /system/bin/app_process32.old ];then
 	mv /system/bin/app_process32 /system/bin/app_process32.old
 fi

--- a/Superuser/build-zip.sh
+++ b/Superuser/build-zip.sh
@@ -8,7 +8,7 @@ pushd "$tmpdir"
 mkdir -p META-INF/com/google/android
 cp "$ORIG"/assets/update-binary META-INF/com/google/android/update-binary
 cp "$ORIG"/assets/install-recovery.sh .
-cp -R "$ORIG"/libs/{x86,mips,armeabi} .
+cp -R "$ORIG"/libs/{x86,x86_64,armeabi,arm64-v8a,mips,mips64} .
 
 zip -r "$ORIG"/update-su.zip *
 popd

--- a/Superuser/jni/Application.mk
+++ b/Superuser/jni/Application.mk
@@ -1,3 +1,3 @@
-APP_ABI := x86 armeabi mips
+APP_ABI := x86 x86_64 armeabi arm64-v8a mips mips64
 # NDK_TOOLCHAIN_VERSION=4.8
 APP_PIE = true


### PR DESCRIPTION
General idea is in the future 64-bit devices may need differing hooks since app_process32 may well never be called in privileged mode.  Perhaps not yet _required_, but certainly something to be watching for.
