### PR TITLE
Fix bind removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You'll need the "Widgets" dependency.
 These repositories do not keep the actual projects in the top level directory.
 This is because they contain tests, libs, and samples.
 
-Make sure the SDK Platform for API 19 is installed, through the Android SDK Manager.  Install NDK Revision 9b from [here](http://developer.android.com/tools/sdk/ndk/index.html).
+Make sure the SDK Platform for API 19 is installed, through the Android SDK Manager.  Install NDK Revision 9b from [here](http://developer.android.com/tools/sdk/ndk/index.html) or use the latest and set NDK_TOOLCHAIN_VERSION=4.9.
 
 ## Building the su and placeholder binaries
 

--- a/Superuser/jni/su/binds.c
+++ b/Superuser/jni/su/binds.c
@@ -39,7 +39,7 @@
 int bind_foreach(bind_cb cb, void* arg) {
     int res = 0;
     char *str = NULL;
-	int fd = open("/data/su/binds", O_RDONLY);
+	int fd = open(BINDS_PATH, O_RDONLY);
     if(fd<0)
         return 1;
 
@@ -120,8 +120,8 @@ int bind_remove(const char *path, int uid) {
 	_found = 0;
 	_uid = uid;
 
-	unlink("/data/su/bind.new");
-	_fd = open("/data/su/bind.new", O_WRONLY|O_CREAT, 0600);
+	unlink(BINDS_TMP_PATH);
+	_fd = open(BINDS_TMP_PATH, O_WRONLY|O_CREAT, 0600);
 	if(_fd<0)
 		return 0;
 
@@ -139,8 +139,8 @@ int bind_remove(const char *path, int uid) {
     }
     bind_foreach(cb, NULL);
 	close(_fd);
-	unlink("/data/su/bind");
-	rename("/data/su/bind.new", "/data/su/bind");
+	unlink(BINDS_PATH);
+	rename(BINDS_TMP_PATH, BINDS_PATH);
 	return _found;
 }
 

--- a/Superuser/jni/su/binds.h
+++ b/Superuser/jni/su/binds.h
@@ -17,6 +17,9 @@
 #ifndef BINDSH
 #define BINDS_H
 
+#define BINDS_PATH "/data/su/binds"
+#define BINDS_TMP_PATH "/data/su/binds.new"
+
 typedef void (*bind_cb)(void *arg, int uid, const char *src, const char *dst);
 extern int bind_foreach(bind_cb cb, void* arg);
 extern int bind_uniq_dst(const char *dst);

--- a/Superuser/jni/su/binds.h
+++ b/Superuser/jni/su/binds.h
@@ -14,7 +14,7 @@
    Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-#ifndef BINDSH
+#ifndef BINDS_H
 #define BINDS_H
 
 #define BINDS_PATH "/data/su/binds"

--- a/Superuser/jni/su/daemon.c
+++ b/Superuser/jni/su/daemon.c
@@ -460,7 +460,7 @@ static int copy_file(const char* src, const char* dst, int mode) {
 	int ofd = open(dst, O_WRONLY|O_CREAT, mode);
 	if(ofd<0)
 		return 1;
-	size_t s = lseek(ifd, 0, SEEK_END);
+	off_t s = lseek(ifd, 0, SEEK_END);
 	if(s<0)
 		return 1;
 	lseek(ifd, 0, SEEK_SET);

--- a/Superuser/jni/su/su.c
+++ b/Superuser/jni/su/su.c
@@ -491,7 +491,7 @@ static __attribute__ ((noreturn)) void allow_bind(struct su_context *ctx) {
         fprintf(stderr, "BIND: Distant file NOT unique. I refuse.\n");
         exit(1);
     }
-	int fd = open("/data/su/binds", O_WRONLY|O_APPEND|O_CREAT, 0600);
+	int fd = open(BINDS_PATH, O_WRONLY|O_APPEND|O_CREAT, 0600);
 	if(fd<0) {
 		fprintf(stderr, "Failed to open binds file\n");
         exit(1);


### PR DESCRIPTION
**Description:**
bind_remove create a temp file (data/su/bind.new) with all bound files except removed one and moved it to /data/su/bind file whereas configuration to replace is /data/su/binds (with a final s).

Also fix minor issues:
- An header redefinition protection
- A error handling

And update manifest for native build instruction as ndk 9b is no more available for download on ndk home page.