### PR TITLE
Fix prepare_su_bind check

### DIFF
--- a/Superuser/jni/su/daemon.c
+++ b/Superuser/jni/su/daemon.c
@@ -476,7 +476,7 @@ static void prepare_su_bind() {
 	int ret = 0;
 
 	//Check if there is a use to mount bind
-	if(access("/system/xbin/su", R_OK) != 0)
+	if(access("/system/xbin/su", R_OK) == 0)
 		return;
 
 	ret = copy_file("/sbin/su", "/dev/su/su", 0755);


### PR DESCRIPTION
/system/xbin/su presence is checked before trying to mount it.
The check was inverted. If bound su is missing, prepare method exits
instead of mounting su file.